### PR TITLE
fix: 🐛 Fix broken `main` field in hooks, utils and react-contex

### DIFF
--- a/.changeset/bold-banks-cross.md
+++ b/.changeset/bold-banks-cross.md
@@ -1,0 +1,15 @@
+---
+"@vega-ui/react-context": patch
+"@vega-ui/hooks": patch
+"@vega-ui/utils": patch
+---
+
+Fix broken `main` field in hooks, utils and react-context
+
+In `@vega-ui/hooks`, `@vega-ui/utils` and `@vega-ui/react-context` the `main` field pointed to `./dist/index.ts` — a file that doesn't exist in `dist/` (the build only outputs `.js` and `.d.ts`). Modern bundlers masked the problem by resolving through the `exports` map, but environments that rely on `main` (Node without conditional exports support, Jest with legacy resolution, ts-node, CDNs like esm.sh) got `MODULE_NOT_FOUND` or tried to parse TypeScript as JS.
+
+Changes:
+
+- `main` now points to `./dist/index.js`
+- added `module: "./dist/index.js"` (consistent with `@vega-ui/react`)
+- added the missing top-level `types: "./dist/index.d.ts"` to utils and react-context so resolvers that don't support `exports` can find the type declarations

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -16,7 +16,8 @@
   },
   "homepage": "https://github.com/vega-ui/ui#readme",
   "type": "module",
-  "main": "./dist/index.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/react-context/package.json
+++ b/packages/react-context/package.json
@@ -16,7 +16,9 @@
   },
   "homepage": "https://github.com/vega-ui/ui#readme",
   "type": "module",
-  "main": "./dist/index.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "source": "./src/index.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,9 @@
   },
   "homepage": "https://github.com/vega-ui/ui#readme",
   "type": "module",
-  "main": "./dist/index.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "source": "./src/index.ts",


### PR DESCRIPTION
Fix broken `main` field in hooks, utils and react-context

In `@vega-ui/hooks`, `@vega-ui/utils` and `@vega-ui/react-context` the `main` field pointed to `./dist/index.ts` — a file that doesn't exist in `dist/` (the build only outputs `.js` and `.d.ts`). Modern bundlers masked the problem by resolving through the `exports` map, but environments that rely on `main` (Node without conditional exports support, Jest with legacy resolution, ts-node, CDNs like esm.sh) got `MODULE_NOT_FOUND` or tried to parse TypeScript as JS.

Changes:

- `main` now points to `./dist/index.js`
- added `module: "./dist/index.js"` (consistent with `@vega-ui/react`)
- added the missing top-level `types: "./dist/index.d.ts"` to utils and react-context so resolvers that don't support `exports` can find the type declarations
