### PR TITLE
fix: 🐛 Declare `react` as a peer dependency

### DIFF
--- a/.changeset/proud-context-peers.md
+++ b/.changeset/proud-context-peers.md
@@ -1,0 +1,9 @@
+---
+"@vega-ui/react-context": patch
+---
+
+Declare `react` as a peer dependency
+
+`@vega-ui/react-context` uses React but did not declare it as a dependency of any kind — only `devDependencies`. A consumer installing just `@vega-ui/react-context` got no hint about the required React version, and with Yarn PnP / strict resolution React could not be resolved at all.
+
+Added `"peerDependencies": { "react": "^19.0.0" }` (only `react` — the package does not use `react-dom`).

--- a/packages/react-context/package.json
+++ b/packages/react-context/package.json
@@ -36,6 +36,9 @@
     "build": "vite build",
     "check-types": "tsc --noEmit"
   },
+  "peerDependencies": {
+    "react": "^19.0.0"
+  },
   "devDependencies": {
     "@types/react": "^19.0.10",
     "@vitejs/plugin-react": "^4.3.4",


### PR DESCRIPTION
`@vega-ui/react-context` uses React but did not declare it as a dependency of any kind — only `devDependencies`. A consumer installing just `@vega-ui/react-context` got no hint about the required React version, and with Yarn PnP / strict resolution React could not be resolved at all.

Added `"peerDependencies": { "react": "^19.0.0" }` (only `react` — the package does not use `react-dom`).