### PR TITLE
fix: 🐛 Replace `lucide-react: "latest"` with a semver range

### DIFF
--- a/.changeset/lucid-icons-range.md
+++ b/.changeset/lucid-icons-range.md
@@ -1,0 +1,9 @@
+---
+"@vega-ui/icons": minor
+---
+
+Replace `lucide-react: "latest"` with a semver range and upgrade to 1.x
+
+`latest` is an npm dist-tag, not a semver range: every clean install could resolve a different version, and a breaking lucide release would hit consumers immediately with no way to protect themselves. The lockfile also masked a real drift — local/CI installs resolved `0.577.0` while a fresh consumer install of `latest` already got `1.23.0`.
+
+Changed to `"lucide-react": "^1.23.0"`: new 1.x minors (which is how lucide ships new icons) keep flowing in on install, but a future breaking 2.0 won't be picked up silently. Verified against 1.23.0: icons and ui packages build and typecheck, Icon/IconButton browser tests pass in Chromium, Firefox and WebKit.

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -31,7 +31,7 @@
     "react-dom": "^19.0.0"
   },
   "dependencies": {
-    "lucide-react": "latest"
+    "lucide-react": "^1.23.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
   packages/icons:
     dependencies:
       lucide-react:
-        specifier: latest
-        version: 0.577.0(react@19.2.3)
+        specifier: ^1.23.0
+        version: 1.23.0(react@19.2.3)
     devDependencies:
       '@types/react':
         specifier: ^19.0.10
@@ -2096,8 +2096,8 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
-  lucide-react@0.577.0:
-    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
+  lucide-react@1.23.0:
+    resolution: {integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -4921,7 +4921,7 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  lucide-react@0.577.0(react@19.2.3):
+  lucide-react@1.23.0(react@19.2.3):
     dependencies:
       react: 19.2.3
 


### PR DESCRIPTION
Replace `lucide-react: "latest"` with a semver range and upgrade to 1.x

`latest` is an npm dist-tag, not a semver range: every clean install could resolve a different version, and a breaking lucide release would hit consumers immediately with no way to protect themselves. The lockfile also masked a real drift — local/CI installs resolved `0.577.0` while a fresh consumer install of `latest` already got `1.23.0`.

Changed to `"lucide-react": "^1.23.0"`: new 1.x minors (which is how lucide ships new icons) keep flowing in on install, but a future breaking 2.0 won't be picked up silently. Verified against 1.23.0: icons and ui packages build and typecheck, Icon/IconButton browser tests pass in Chromium, Firefox and WebKit.
