### PR TITLE
fix: 🐛 Fix inverted `useIsomorphicLayoutEffect`

### DIFF
--- a/.changeset/hooks-isomorphic-layout-effect.md
+++ b/.changeset/hooks-isomorphic-layout-effect.md
@@ -1,0 +1,9 @@
+---
+"@vega-ui/hooks": patch
+---
+
+Fix inverted `useIsomorphicLayoutEffect`
+
+The ternary picked `useLayoutEffect` on the server and `useEffect` in the browser — exactly backwards. On SSR this triggered React's "useLayoutEffect does nothing on the server" warning; in the browser, everything built on the hook (`useLatest`, and through it layout measurements in `useResize`/`useScrollSnap` consumers) ran after paint instead of before it, allowing a frame of stale layout.
+
+Also renamed the file to fix the typo: `useIsomophicLayoutEffect.ts` → `useIsomorphicLayoutEffect.ts` (internal only — the exported name was always spelled correctly).

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,5 +1,5 @@
 export * from './useResize'
-export * from './useIsomophicLayoutEffect'
+export * from './useIsomorphicLayoutEffect'
 export * from './useLatest'
 export * from './useControlledState'
 export * from './useRefMap'

--- a/packages/hooks/src/useIsomophicLayoutEffect.ts
+++ b/packages/hooks/src/useIsomophicLayoutEffect.ts
@@ -1,3 +1,0 @@
-import { useEffect, useLayoutEffect } from 'react';
-
-export const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useLayoutEffect : useEffect

--- a/packages/hooks/src/useIsomorphicLayoutEffect.ts
+++ b/packages/hooks/src/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,3 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+export const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect

--- a/packages/hooks/src/useLatest.ts
+++ b/packages/hooks/src/useLatest.ts
@@ -1,6 +1,6 @@
 import type { RefObject } from 'react'
 import { useRef } from 'react'
-import { useIsomorphicLayoutEffect } from './useIsomophicLayoutEffect'
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 export const useLatest = <T>(value: T): RefObject<T> => {
   const ref = useRef(value)


### PR DESCRIPTION
The ternary picked `useLayoutEffect` on the server and `useEffect` in the browser — exactly backwards. On SSR this triggered React's "useLayoutEffect does nothing on the server" warning; in the browser, everything built on the hook (`useLatest`, and through it layout measurements in `useResize`/`useScrollSnap` consumers) ran after paint instead of before it, allowing a frame of stale layout.

Also renamed the file to fix the typo: `useIsomophicLayoutEffect.ts` → `useIsomorphicLayoutEffect.ts` (internal only — the exported name was always spelled correctly).
