### PR TITLE
fix: 🐛 Fix crash paths and null/undefined confusion in

### DIFF
--- a/.changeset/hooks-scroll-snap-guards.md
+++ b/.changeset/hooks-scroll-snap-guards.md
@@ -1,0 +1,9 @@
+---
+"@vega-ui/hooks": patch
+---
+
+Fix crash paths and null/undefined confusion in `useScrollSnap`
+
+`getPointed()` returns `undefined` when the scroller ref is not attached, but `measure()` dereferenced its result unconditionally (TypeError on mount when the scroller renders later, or when calling the public `measure()` too early), and `commit()` destructured it unconditionally (TypeError when the scroller leaves the DOM while a debounced commit is pending). With an empty scroller (no registered items) `onSnapChange`/`onSnapChanging` fired with `(undefined, undefined)` despite their `(el: HTMLElement, key: K)` signatures, and the `key !== null` guard in `commit` never worked because `key` was `K | undefined`, never `null`.
+
+Now: `getPointed` normalizes misses to `null` and all callers guard against an absent scroller; snap callbacks only fire with a real element and key; `measure()` skips items whose snap point cannot be computed instead of storing `undefined` in the points map; `scrollToElement` no longer looks up points with an `undefined` key.

--- a/packages/hooks/src/useScrollSnap.ts
+++ b/packages/hooks/src/useScrollSnap.ts
@@ -115,13 +115,15 @@ export const useScrollSnap = <K extends string | number, E extends HTMLElement>(
     
     const scrollOffset = axis === 'x' ? s.scrollLeft : s.scrollTop;
     const pointsArray = Array.from(points.values()).sort((a, b) => a - b);
-    
+
     const nearestIndex = nearest(pointsArray, scrollOffset)
+    if (nearestIndex === -1) return { key: null, element: null }
+
     const nearestOffset = pointsArray[nearestIndex]
-    
-    const key = points.getByValue(nearestOffset)
-    const element = items.getByKey(key)
-    
+
+    const key = points.getByValue(nearestOffset) ?? null
+    const element = (key !== null ? items.getByKey(key) : null) ?? null
+
     return { key, element }
   }, [axis])
   
@@ -131,18 +133,24 @@ export const useScrollSnap = <K extends string | number, E extends HTMLElement>(
     for (const key of items.keys()) {
       const element = items.getByKey(key);
       if (!element) continue;
-      points.set(key, calculateSnapPoint(element));
+
+      const point = calculateSnapPoint(element);
+      if (point == null) continue;
+
+      points.set(key, point);
     }
-    
+
     const pointed = getPointed();
-    const existsCommitted = committedKey.current !== undefined && items.getByKey(committedKey.current) != null;
-    
-    if (committedKey.current === undefined || !existsCommitted) {
+    if (!pointed) return;
+
+    const existsCommitted = committedKey.current !== null && items.getByKey(committedKey.current) != null;
+
+    if (!existsCommitted) {
       committedKey.current = pointed.key;
       pendingKey.current = pointed.key;
       return;
     }
-    
+
     if (pointed.key !== committedKey.current) {
       committedKey.current = pointed.key;
       pendingKey.current = pointed.key;
@@ -165,13 +173,16 @@ export const useScrollSnap = <K extends string | number, E extends HTMLElement>(
   useResizeObserver(scrollerRef, scheduleMeasure)
   
   const commit = useCallback(() => {
-    const { key, element } = getPointed()
-    
-    if (key !== null && key === committedKey.current) return;
-    
+    const pointed = getPointed()
+    if (!pointed) return;
+
+    const { key, element } = pointed;
+
+    if (key === committedKey.current) return;
+
     committedKey.current = key;
     pendingKey.current = key;
-    onSnapChange?.(element, key);
+    if (element && key !== null) onSnapChange?.(element, key);
   }, [onSnapChange, getPointed])
   
   const scheduleCommitFallback = useCallback(() => {
@@ -187,12 +198,15 @@ export const useScrollSnap = <K extends string | number, E extends HTMLElement>(
       rafScrollId.current = null;
       
       if (!points.size) scheduleMeasure();
-      
-      const { key, element } = getPointed(target)
-      
+
+      const pointed = getPointed(target)
+      if (!pointed) return;
+
+      const { key, element } = pointed;
+
       if (key !== pendingKey.current) {
         pendingKey.current = key;
-        onSnapChanging?.(element, key);
+        if (element && key !== null) onSnapChanging?.(element, key);
       }
 
       // Native-like: commit only on real scroll end when possible
@@ -207,9 +221,9 @@ export const useScrollSnap = <K extends string | number, E extends HTMLElement>(
     if (!points.size) scheduleMeasure();
     
     const key = items.getByValue(el)
-    const target = points.getByKey(key) ?? calculateSnapPoint(el);
-    
-    if (!Number.isFinite(target)) return;
+    const target = (key !== undefined ? points.getByKey(key) : undefined) ?? calculateSnapPoint(el);
+
+    if (target == null || !Number.isFinite(target)) return;
 
     if (axis === 'y') {
       scroller.scrollTo({ top: target, behavior });

--- a/packages/ui/src/SnapScroller/__tests__/SnapScroller.browser.test.tsx
+++ b/packages/ui/src/SnapScroller/__tests__/SnapScroller.browser.test.tsx
@@ -240,6 +240,47 @@ describe('SnapScroller', () => {
       expect(apiRef.current?.scrollToElementByKey).toBeTypeOf('function');
     });
     
+    it('does not emit snap callbacks when a snap point resolves to a stale item', async () => {
+      const onScrollSnapChanging = vi.fn();
+      const onScrollSnapChange = vi.fn();
+      const apiRef = createRef<SnapScrollerApiRef>();
+
+      const content = (secondIndex: number) => (
+        <>
+          <SnapScrollerContent data-testid='item-0' index={0} style={{ width: ITEM_SIZE, flexShrink: 0 }}>
+            Item 0
+          </SnapScrollerContent>
+          <SnapScrollerContent data-testid='item-1' index={secondIndex} style={{ width: ITEM_SIZE, flexShrink: 0 }}>
+            Item 1
+          </SnapScrollerContent>
+        </>
+      );
+
+      const props = { apiRef, onScrollSnapChanging, onScrollSnapChange };
+      const r = render(<SnapScrollerTest {...props}>{content(1)}</SnapScrollerTest>);
+      const scroller = getScroller(r);
+
+      await waitFor(() => {
+        expect(apiRef.current?.getCommited?.()).toBe(0);
+      });
+
+      r.rerender(<SnapScrollerTest {...props}>{content(5)}</SnapScrollerTest>);
+
+      scroller.scrollTo({ left: 150, top: 0, behavior: 'auto' });
+
+      await waitFor(() => {
+        expect(apiRef.current?.getPending?.()).toBe(1);
+      });
+
+      scroller.dispatchEvent(new Event('scrollend'));
+      await waitFor(() => {
+        expect(apiRef.current?.getCommited?.()).toBe(1);
+      });
+
+      expect(onScrollSnapChanging).not.toHaveBeenCalled();
+      expect(onScrollSnapChange).not.toHaveBeenCalled();
+    });
+
     it('prev()/next() do not throw when committed index is not yet available', async () => {
       const apiRef = createRef<SnapScrollerApiRef>();
       render(<SnapScrollerTest apiRef={apiRef} />);


### PR DESCRIPTION
Fix crash paths and null/undefined confusion in `useScrollSnap`

`getPointed()` returns `undefined` when the scroller ref is not attached, but `measure()` dereferenced its result unconditionally (TypeError on mount when the scroller renders later, or when calling the public `measure()` too early), and `commit()` destructured it unconditionally (TypeError when the scroller leaves the DOM while a debounced commit is pending). With an empty scroller (no registered items) `onSnapChange`/`onSnapChanging` fired with `(undefined, undefined)` despite their `(el: HTMLElement, key: K)` signatures, and the `key !== null` guard in `commit` never worked because `key` was `K | undefined`, never `null`.

Now: `getPointed` normalizes misses to `null` and all callers guard against an absent scroller; snap callbacks only fire with a real element and key; `measure()` skips items whose snap point cannot be computed instead of storing `undefined` in the points map; `scrollToElement` no longer looks up points with an `undefined` key.