### PR TITLE
fix: 🐛 Read fresh value/disabled in Slider changeValue

### DIFF
--- a/.changeset/slider-stale-closure.md
+++ b/.changeset/slider-stale-closure.md
@@ -1,0 +1,9 @@
+---
+"@vega-ui/react": patch
+---
+
+Fix stale closure in Slider's `changeValue`
+
+`changeValue` was wrapped in `useCallback` with empty deps, freezing `value` and `disabled` at their first-render values. Consequences: the slider could never return to its initial value (keyboard stepping got stuck one step away from it, clicking the initial track position was ignored); the same-value dedup guard compared against the initial value instead of the current one, so `onChangeValue` fired repeatedly with identical values during drags; toggling `disabled` after mount had no effect on interactions (an initially enabled slider stayed interactive when disabled, an initially disabled one stayed dead when enabled).
+
+The memoization served no purpose — `changeValue` is only used by handlers that are recreated on every render — so it is now a plain function reading fresh props. Covered with regression tests for all three symptoms.

--- a/packages/ui/src/Slider/Slider.tsx
+++ b/packages/ui/src/Slider/Slider.tsx
@@ -1,4 +1,4 @@
-import { FC, HTMLAttributes, PointerEvent, KeyboardEvent, MouseEvent, useRef, useCallback } from 'react';
+import { FC, HTMLAttributes, PointerEvent, KeyboardEvent, MouseEvent, useRef } from 'react';
 
 import { clamp, safeSetPointerCapture } from '@vega-ui/utils';
 import { useControlledState } from '@vega-ui/hooks';
@@ -85,11 +85,11 @@ export const Slider: FC<SliderProps> = ({
   const [value, setValue] = useControlledState(controlledValue, defaultValue, onChangeValue)
   const dragging = useRef(false)
 
-  const changeValue = useCallback((newValue: number) => {
+  const changeValue = (newValue: number) => {
     if (disabled || newValue === value) return
 
     setValue(newValue)
-  }, [])
+  }
 
   const calcValue = (e: PointerEvent | MouseEvent) => {
     const track = sliderRef.current

--- a/packages/ui/src/Slider/__tests__/Slider.browser.test.tsx
+++ b/packages/ui/src/Slider/__tests__/Slider.browser.test.tsx
@@ -361,6 +361,47 @@ describe('Slider', () => {
       await expect.element(getInput(r)).toHaveValue(String(MIN));
     });
     
+    it('returns to the initial value after moving away (ArrowRight then ArrowLeft)', async () => {
+      const STEP = 10;
+      const r = render(<SliderTest defaultValue={DEFAULT_VALUE} step={STEP} />);
+
+      const thumb = getThumb(r);
+      thumb.focus();
+
+      await userEvent.keyboard('{ArrowRight}');
+      await userEvent.keyboard('{ArrowLeft}');
+
+      await expect.element(getInput(r)).toHaveValue(String(DEFAULT_VALUE));
+    });
+
+    it('does not repeat onChangeValue for the same value during drag', async () => {
+      const onChangeValue = vi.fn();
+      const r = render(<SliderTest defaultValue={DEFAULT_VALUE} onChangeValue={onChangeValue} />);
+
+      const thumb = getThumb(r);
+
+      fireEvent.pointerDown(thumb, { pointerId: 1, pointerType: 'touch', clientX: 999, clientY: 0 });
+      fireEvent.pointerMove(thumb, { pointerId: 1, pointerType: 'touch', clientX: 999, clientY: 0 });
+      fireEvent.pointerUp(thumb, { pointerId: 1, pointerType: 'touch', clientX: 999, clientY: 0 });
+
+      expect(onChangeValue).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops reacting when disabled after mount', async () => {
+      const onChangeValue = vi.fn();
+      const r = render(<SliderTest defaultValue={DEFAULT_VALUE} onChangeValue={onChangeValue} />);
+
+      r.rerender(<SliderTest defaultValue={DEFAULT_VALUE} disabled onChangeValue={onChangeValue} />);
+
+      const thumb = getThumb(r);
+      thumb.focus();
+
+      await userEvent.keyboard('{ArrowRight}');
+
+      expect(onChangeValue).not.toHaveBeenCalled();
+      await expect.element(getInput(r)).toHaveValue(String(DEFAULT_VALUE));
+    });
+
     it('uses computed defaultValue when defaultValue is not provided', async () => {
       const r = render(<SliderTest />);
       


### PR DESCRIPTION
Fix stale closure in Slider's `changeValue`

`changeValue` was wrapped in `useCallback` with empty deps, freezing `value` and `disabled` at their first-render values. Consequences: the slider could never return to its initial value (keyboard stepping got stuck one step away from it, clicking the initial track position was ignored); the same-value dedup guard compared against the initial value instead of the current one, so `onChangeValue` fired repeatedly with identical values during drags; toggling `disabled` after mount had no effect on interactions (an initially enabled slider stayed interactive when disabled, an initially disabled one stayed dead when enabled).

The memoization served no purpose — `changeValue` is only used by handlers that are recreated on every render — so it is now a plain function reading fresh props. Covered with regression tests for all three symptoms.