### PR TITLE
fix: 🐛 Select typeahead no longer skips options with falsy val

### DIFF
--- a/.changeset/select-falsy-typeahead.md
+++ b/.changeset/select-falsy-typeahead.md
@@ -1,0 +1,7 @@
+---
+"@vega-ui/react": patch
+---
+
+Fix Select typeahead skipping options with falsy values
+
+`onMatch` (typeahead selection while the listbox is closed) guarded the matched value with `if (!value) return`, so options whose value is `0` or an empty string could be highlighted but never actually selected — common with numeric IDs. The guard now checks for `undefined` (a missing map entry) only. Covered with a regression test that selects a `value={0}` option by typing.

--- a/packages/ui/src/Select/Select.tsx
+++ b/packages/ui/src/Select/Select.tsx
@@ -166,8 +166,8 @@ export const Select = <V extends string | number>({
     setSelectedIndex(index)
     
     const value = indexValueMap.get(index)
-    if (!value) return
-    
+    if (value === undefined) return
+
     select(value)
   }
   

--- a/packages/ui/src/Select/__tests__/Select.browser.test.tsx
+++ b/packages/ui/src/Select/__tests__/Select.browser.test.tsx
@@ -388,6 +388,32 @@ describe('Select', () => {
           });
         });
         
+        it('selects an option with a falsy value (0) by typing', async () => {
+          const onSelectValue = vi.fn();
+
+          const r2 = render(
+            <Select data-testid='select-numeric' onSelectValue={onSelectValue}>
+              <SelectCombobox data-testid='combobox-numeric'>
+                <SelectValue placeholder={PLACEHOLDER} />
+              </SelectCombobox>
+
+              <SelectPortal>
+                <SelectListbox>
+                  <SelectOption value={0}>Zero</SelectOption>
+                  <SelectOption value={1}>One</SelectOption>
+                </SelectListbox>
+              </SelectPortal>
+            </Select>,
+          );
+
+          (r2.getByTestId('combobox-numeric') as HTMLElement).focus();
+          await userEvent.keyboard('zer');
+
+          await waitFor(() => {
+            expect(onSelectValue).toHaveBeenCalledWith(0);
+          });
+        });
+
         it('does not auto-select while open (typing only searches)', async () => {
           const onSelectValue = vi.fn();
           r.rerender(<SelectTest defaultValue='' onOpenChange={vi.fn()} onSelectValue={onSelectValue} />);


### PR DESCRIPTION
Fix Select typeahead skipping options with falsy values

`onMatch` (typeahead selection while the listbox is closed) guarded the matched value with `if (!value) return`, so options whose value is `0` or an empty string could be highlighted but never actually selected — common with numeric IDs. The guard now checks for `undefined` (a missing map entry) only. Covered with a regression test that selects a `value={0}` option by typing.